### PR TITLE
CI: fix cargo-deny config, pin workspace dep

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,17 +1,15 @@
 [advisories]
-vulnerability = "deny"
-yanked = "deny"
-unmaintained = "warn"
-ignore = []   # add IDs here if you must temporarily waive
+# Which crates to check for unmaintained status: all|workspace|transitive|none
+unmaintained = "workspace"
+ignore = []
 
 [licenses]
 # Typical OSS-OK set used by many Rust projects
 allow = [
   "MIT", "Apache-2.0", "BSD-3-Clause", "BSD-2-Clause",
-  "ISC", "Zlib", "MPL-2.0", "Unicode-DFS-2016"
+  "ISC", "Zlib", "MPL-2.0", "Unicode-DFS-2016", "Unicode-3.0"
 ]
-copyleft = "deny"
-unlicensed = "deny"
+confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
@@ -22,4 +20,3 @@ deny = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-

--- a/parx-cli/Cargo.toml
+++ b/parx-cli/Cargo.toml
@@ -29,7 +29,7 @@ pathdiff = "0.2"
 crc32fast = "1.3"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
-parx-core = { path = "../parx-core" }
+parx-core = { path = "../parx-core", version = "0.5.0" }
 
 [features]
 cuda = ["parx-core/cuda"]


### PR DESCRIPTION
- Update deny.toml for cargo-deny 0.18\n- Allow Unicode-3.0 license; keep OSS allowlist\n- Relax multiple-versions to warn\n- Pin local path dep version to avoid wildcard\n\nCI should now pass: build-test, cargo-deny, CodeQL