### PR TITLE
CI: remove build-test aggregator; require fmt/clippy/tests

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "pre-push: verifying workspace (fmt, clippy, tests)"
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "cargo not found; skipping checks" >&2
+  exit 0
+fi
+
+# Format check
+cargo fmt --all -- --check
+
+# Clippy (deny warnings)
+cargo clippy --workspace --all-targets -- -D warnings
+
+# Tests (workspace)
+cargo test --workspace
+
+echo "pre-push: all checks passed"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for all files
+* @rTiGd2
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,6 @@ jobs:
       - name: Tests
         run: cargo test --workspace --locked
 
-  build-test:
-    runs-on: ubuntu-latest
-    needs: [fmt, clippy, tests]
-    steps:
-      - name: Aggregate fmt/clippy/tests
-        run: echo "fmt, clippy, and tests passed"
-
   cargo-deny:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,23 +7,43 @@ on:
     branches: [ main, master ]
 
 jobs:
-  build-test:
+  fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' }}
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
       - name: Format check
         run: cargo fmt --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
       - name: Clippy (deny warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Tests
         run: cargo test --workspace --locked
+
+  build-test:
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy, tests]
+    steps:
+      - name: Aggregate fmt/clippy/tests
+        run: echo "fmt, clippy, and tests passed"
 
   cargo-deny:
     runs-on: ubuntu-latest

--- a/deny.toml
+++ b/deny.toml
@@ -1,17 +1,15 @@
 [advisories]
-vulnerability = "deny"
-yanked = "deny"
-unmaintained = "warn"
-ignore = []   # add IDs here if you must temporarily waive
+# Which crates to check for unmaintained status: all|workspace|transitive|none
+unmaintained = "workspace"
+ignore = []
 
 [licenses]
 # Typical OSS-OK set used by many Rust projects
 allow = [
   "MIT", "Apache-2.0", "BSD-3-Clause", "BSD-2-Clause",
-  "ISC", "Zlib", "MPL-2.0", "Unicode-DFS-2016"
+  "ISC", "Zlib", "MPL-2.0", "Unicode-DFS-2016", "Unicode-3.0"
 ]
-copyleft = "deny"
-unlicensed = "deny"
+confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
@@ -22,4 +20,3 @@ deny = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-

--- a/parx-cli/Cargo.toml
+++ b/parx-cli/Cargo.toml
@@ -29,7 +29,7 @@ pathdiff = "0.2"
 crc32fast = "1.3"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
-parx-core = { path = "../parx-core" }
+parx-core = { path = "../parx-core", version = "0.5.0" }
 
 [features]
 cuda = ["parx-core/cuda"]

--- a/parx-cli/Cargo.toml
+++ b/parx-cli/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT OR Apache-2.0"
 description = "ParXive command-line interface using parx-core."
 readme = false
 repository = "https://github.com/rTiGd2/ParXive"
+rust-version = "1.74"
+keywords = ["parity", "erasure-coding", "integrity", "merkle", "par2"]
+categories = ["command-line-utilities", "filesystem"]
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/parx-core/Cargo.toml
+++ b/parx-core/Cargo.toml
@@ -6,6 +6,9 @@ license = "MIT OR Apache-2.0"
 description = "ParXive core library: erasure coding, volumes, manifest, repair, audit."
 repository = "https://github.com/rTiGd2/ParXive"
 readme = false
+rust-version = "1.74"
+keywords = ["parity", "erasure-coding", "integrity", "merkle", "par2"]
+categories = ["command-line-utilities", "filesystem"]
 
 [features]
 # CUDA backend (optional)

--- a/parx-core/src/repair.rs
+++ b/parx-core/src/repair.rs
@@ -196,11 +196,11 @@ pub fn repair(manifest_path: &Path, root: &Path) -> Result<RepairReport> {
                     }
                 }
                 let _ = f.sync_all();
-                let _ = f.unlock();
+                // unlocking happens on drop; avoid std::File::unlock (MSRV >=1.89)
             }
         }
     }
 
-    let _ = lock_file.unlock();
+    // Release global lock on drop
     Ok(RepairReport { repaired_chunks, failed_chunks })
 }

--- a/scripts/update_required_checks.sh
+++ b/scripts/update_required_checks.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OWNER=${1:-rTiGd2}
+REPO=${2:-ParXive}
+BR=${3:-main}
+
+echo "Updating required status checks for $OWNER/$REPO:$BR"
+
+# Desired contexts
+contexts=(
+  "fmt"
+  "clippy"
+  "tests"
+  "cargo-deny"
+  "Analyze"
+)
+
+# Build JSON array of contexts
+ctx_json=$(printf '%s\n' "${contexts[@]}" | jq -Rcs 'split("\n") | map(select(length>0))')
+
+json=$(jq -n --argjson contexts "$ctx_json" '{
+  required_status_checks: { strict: true, contexts: $contexts },
+  enforce_admins: true,
+  required_pull_request_reviews: { required_approving_review_count: 1 },
+  restrictions: null,
+  allow_force_pushes: false,
+  allow_deletions: false,
+  required_linear_history: true
+}')
+
+printf '%s' "$json" | gh api -X PUT repos/$OWNER/$REPO/branches/$BR/protection -H "Accept: application/vnd.github+json" --input -
+echo
+echo "Done. Note: ensure jobs exist before making them required."
+


### PR DESCRIPTION
Now that fmt, clippy, and tests are separate jobs, this removes the temporary build-test aggregator.\n\nBefore merging, run scripts/update_required_checks.sh to update branch protections to require: fmt, clippy, tests, cargo-deny, Analyze.