### PR TITLE
feat: file interleaving option; protections guard + scripts; README cleanup; benchmarks plan

### DIFF
--- a/.github/workflows/branch-protection-guard.yml
+++ b/.github/workflows/branch-protection-guard.yml
@@ -1,0 +1,92 @@
+name: Branch Protection Guard
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '19 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  # administration: read is implicitly allowed for reading protection in same-repo context
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch protection and open issue on drift
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = 'main';
+
+            // Desired settings
+            const desiredChecks = ['fmt','clippy','tests','cargo-deny','Analyze (rust)'];
+            const desiredReviews = 1;
+            const desiredAdmins = true;
+            const desiredLinearHistory = true;
+
+            async function getProtection() {
+              try {
+                const res = await github.request('GET /repos/{owner}/{repo}/branches/{branch}/protection', { owner, repo, branch });
+                return res.data;
+              } catch (e) {
+                core.warning('Protection GET failed: ' + e.message);
+                return null;
+              }
+            }
+
+            async function getSignatures() {
+              try {
+                const res = await github.request('GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures', { owner, repo, branch });
+                return !!res.data.enabled;
+              } catch (e) {
+                core.warning('Signature GET failed: ' + e.message);
+                return false;
+              }
+            }
+
+            const prot = await getProtection();
+            const signaturesEnabled = await getSignatures();
+
+            const contexts = prot?.required_status_checks?.contexts || [];
+            const reviews = prot?.required_pull_request_reviews?.required_approving_review_count ?? 0;
+            const admins = prot?.enforce_admins?.enabled ?? false;
+            const linear = prot?.required_linear_history?.enabled ?? false;
+
+            const miss = [];
+            const haveSet = new Set(contexts);
+            const wantSet = new Set(desiredChecks);
+            for (const c of desiredChecks) if (!haveSet.has(c)) miss.push(`missing check: ${c}`);
+            for (const c of contexts) if (!wantSet.has(c)) miss.push(`extra check: ${c}`);
+            if (reviews !== desiredReviews) miss.push(`reviews=${reviews} != ${desiredReviews}`);
+            if (admins !== desiredAdmins) miss.push(`enforce_admins=${admins} != ${desiredAdmins}`);
+            if (linear !== desiredLinearHistory) miss.push(`linear_history=${linear} != ${desiredLinearHistory}`);
+            if (!signaturesEnabled) miss.push('required_signatures is disabled');
+
+            if (miss.length) {
+              core.setFailed('Branch protection drift: ' + miss.join('; '));
+              const title = 'Branch protection drift detected';
+              const body = `Detected branch protection drift on ${branch}.\n\n` +
+                `Desired checks: ${JSON.stringify(desiredChecks)}\n` +
+                `Actual checks: ${JSON.stringify(contexts)}\n` +
+                `Desired reviews: ${desiredReviews}, actual: ${reviews}\n` +
+                `Enforce admins desired ${desiredAdmins}, actual ${admins}\n` +
+                `Linear history desired ${desiredLinearHistory}, actual ${linear}\n` +
+                `Signatures required: true, actual ${signaturesEnabled}\n\n` +
+                `To restore: run \`scripts/update_required_checks.sh\` and enable signatures:\n` +
+                `\n  scripts/update_required_checks.sh\n  scripts/enable_required_signatures.sh\n`;
+              const { data: issues } = await github.request('GET /repos/{owner}/{repo}/issues', { owner, repo, state: 'open', per_page: 100 });
+              const existing = issues.find(i => i.title === title);
+              if (existing) {
+                await github.request('PATCH /repos/{owner}/{repo}/issues/{issue_number}', { owner, repo, issue_number: existing.number, body });
+              } else {
+                await github.request('POST /repos/{owner}/{repo}/issues', { owner, repo, title, body });
+              }
+            } else {
+              core.info('Branch protection matches desired configuration.');
+            }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ cargo test --workspace
 
 ```bash
 # Create parity (35% over stripes of 64, 1 MiB chunks)
+parx create \
+  --parity 35 \
+  --stripe-k 64 \
+  --chunk-size 1048576 \
+  --output .parx \
+  --volume-sizes 32M,32M,32M \
+  ./demo_data
 
 # Verify source files against manifest
 ./target/release/parx verify .parx/manifest.json .
@@ -34,6 +41,8 @@ cargo test --workspace
 # Attempt repair (uses per-stripe RS + parity entries in volumes)
 ./target/release/parx repair .parx/manifest.json .
 ```
+
+- Interleaving across files: add `--interleave-files` to distribute chunks round‑robin across files per stripe. This increases resilience to full-file loss by ensuring each stripe spans multiple input files.
 
 ## Why ParXive (vs PAR2)
 
@@ -51,17 +60,11 @@ cargo test --workspace
 - Outer RS (parity-of-parity) decode path.
 - Optional CUDA batched RS kernels for big sets.
 - PAR2 interop (reader/writer) as a separate crate.
+- Benchmark suite: unbiased, scientific comparison of ParXive vs current popular PAR2 implementations (speed and capabilities). Include our future Rust+GPU par1/par2 library, and also compare our par2 vs ParXive. Produce an HTML and/or PDF report with clear visuals and plain-language explanations, suitable for non-experts.
 
 ## License
 
 Dual-licensed under **MIT** and **Apache-2.0** — pick one or both. See `LICENSE-MIT` and `LICENSE-APACHE`.
-./target/release/parx create \
-  --parity 35 \
-  --stripe-k 64 \
-  --chunk-size 1048576 \
-  --output .parx \
-  --volume-sizes 32M,32M,32M \
-  demo_data
 
 ## Usage
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,17 +1,15 @@
 [advisories]
-vulnerability = "deny"
-yanked = "deny"
-unmaintained = "warn"
-ignore = []   # add IDs here if you must temporarily waive
+# Which crates to check for unmaintained status: all|workspace|transitive|none
+unmaintained = "workspace"
+ignore = []
 
 [licenses]
 # Typical OSS-OK set used by many Rust projects
 allow = [
   "MIT", "Apache-2.0", "BSD-3-Clause", "BSD-2-Clause",
-  "ISC", "Zlib", "MPL-2.0", "Unicode-DFS-2016"
+  "ISC", "Zlib", "MPL-2.0", "Unicode-DFS-2016", "Unicode-3.0"
 ]
-copyleft = "deny"
-unlicensed = "deny"
+confidence-threshold = 0.8
 
 [bans]
 multiple-versions = "warn"
@@ -22,4 +20,3 @@ deny = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,42 @@
+# Benchmark Plan
+
+Objective: Provide a fair, repeatable, and unbiased performance and capability comparison between ParXive and widely used PAR2 implementations. When our Rust + GPU par1/par2 library is available, include it as an additional subject and also compare our par2 vs ParXive.
+
+Principles
+- Reproducible: fully scripted runs with fixed seeds and pinned versions.
+- Representative: datasets spanning single large files and many small files; various chunk sizes and stripe-K.
+- Unbiased: pre-register hypotheses, publish raw data and code; use identical hardware and isolation for each run.
+- Transparent: report methodology, environment, inputs, and full results; include error bars and confidence intervals where applicable.
+
+Datasets
+- Single large file (e.g., 20 GB);
+- Many medium files (e.g., 20 × 1 GB);
+- Many small files (e.g., 100k files totaling ~20 GB);
+- Mixed file tree with nested directories and sparse files (where supported).
+
+Metrics
+- Encode throughput (MiB/s), wall-clock time, CPU %, memory peak;
+- Verify throughput and detection coverage;
+- Repair success rate vs. loss patterns (random chunk loss, full-file loss, volume loss);
+- Parity overhead vs. configuration (K, parity%).
+
+Outputs
+- Human-friendly HTML report (with charts and narrative) and a PDF version.
+- Machine-readable CSV/JSON raw results for third-party analysis.
+
+Tooling
+- `bench/` scripts to generate datasets, run tools, and collect metrics.
+- Optional: use `hyperfine` for timing, `perf` or `pidstat` for CPU/mem samples.
+- Report generator (Python or Rust) to render HTML (and PDF via wkhtmltopdf/Pandoc).
+
+Anti-bias measures
+- Include all raw outputs in the repo or release artifact;
+- Use consistent flags that are advantageous to each tool (not one-size-fits-none);
+- Validate parity integrity with tool-native verifiers;
+- Predefine scoring and plots before running;
+- Document any anomalies and reruns.
+
+Next Steps
+- Scaffold `bench/` harness and minimal dataset generator.
+- Add CI job to lint/run a tiny smoke benchmark (short dataset) just for script integrity.
+

--- a/parx-cli/Cargo.toml
+++ b/parx-cli/Cargo.toml
@@ -29,7 +29,7 @@ pathdiff = "0.2"
 crc32fast = "1.3"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
-parx-core = { path = "../parx-core" }
+parx-core = { path = "../parx-core", version = "0.5.0" }
 
 [features]
 cuda = ["parx-core/cuda"]

--- a/parx-cli/src/main.rs
+++ b/parx-cli/src/main.rs
@@ -33,6 +33,9 @@ enum Commands {
         stripe_k: usize,
         #[arg(long="chunk-size", default_value_t=1<<20)]
         chunk_size: usize,
+        /// Interleave chunks round-robin across files for resilience to full-file loss
+        #[arg(long = "interleave-files", default_value_t = false)]
+        interleave_files: bool,
         #[arg(long, default_value = ".parx")]
         output: PathBuf,
         /// Comma-separated sizes like 1M,1M,1M (just determines how many volumes & mock entry counts)
@@ -189,6 +192,7 @@ fn main() -> Result<()> {
             parity,
             stripe_k,
             chunk_size,
+            interleave_files,
             output,
             volume_sizes,
             outer_group,
@@ -205,6 +209,7 @@ fn main() -> Result<()> {
                 volumes: sizes.len(),
                 outer_group,
                 outer_parity,
+                interleave_files,
             };
             let _manifest = parx_core::encode::Encoder::encode(&input, &output, &cfg)?;
             // Adjust manifest paths to be relative to current working directory

--- a/parx-core/src/encode.rs
+++ b/parx-core/src/encode.rs
@@ -15,6 +15,7 @@ pub struct EncoderConfig {
     pub volumes: usize,
     pub outer_group: usize,
     pub outer_parity: usize,
+    pub interleave_files: bool,
 }
 
 pub struct Encoder;
@@ -38,17 +39,26 @@ impl Encoder {
             files.push(p.to_path_buf());
         }
 
-        // 2) Chunk and hash
-        let mut file_entries = Vec::new();
-        let mut all_chunk_hashes = Vec::new();
-        let mut chunk_buffers: Vec<Vec<u8>> = Vec::new();
+        // 2) Chunk and hash (collect per-file, assign global order later)
+        struct TmpChunk {
+            buf: Vec<u8>,
+            len: u32,
+            file_offset: u64,
+            hash_hex: String,
+        }
+        struct TmpFile {
+            rel_path: String,
+            size: u64,
+            chunks: Vec<TmpChunk>,
+        }
+
+        let mut tmp_files: Vec<TmpFile> = Vec::new();
         let mut total_bytes: u64 = 0;
-        let mut next_chunk_idx: u64 = 0;
-        for path in files {
-            let rel_path = pathdiff::diff_paths(&path, root)
+        for path in &files {
+            let rel_path = pathdiff::diff_paths(path, root)
                 .unwrap_or_else(|| path.file_name().unwrap().into());
             let rel_path = rel_path.to_string_lossy().to_string();
-            let mut f = File::open(&path).with_context(|| format!("open {:?}", path))?;
+            let mut f = File::open(path).with_context(|| format!("open {:?}", path))?;
             let size = f.metadata()?.len();
             total_bytes += size;
             let mut remaining = size;
@@ -66,24 +76,66 @@ impl Encoder {
                         *b = 0;
                     }
                 }
-                let h = blake3::hash(&buf);
-                let hash_hex = h.to_hex().to_string();
-                all_chunk_hashes.push(h);
-                chunks.push(ChunkRef {
-                    idx: next_chunk_idx,
-                    file_offset,
-                    len: readn as u32,
-                    hash_hex,
-                });
-                chunk_buffers.push(buf);
-                next_chunk_idx += 1;
+                let hash_hex = blake3::hash(&buf).to_hex().to_string();
+                chunks.push(TmpChunk { buf, len: readn as u32, file_offset, hash_hex });
                 remaining -= readn as u64;
                 file_offset += readn as u64;
             }
-            file_entries.push(FileEntry { rel_path, size, chunks });
+            tmp_files.push(TmpFile { rel_path, size, chunks });
         }
 
-        // 3) Merkle root
+        // Assign global ordering: sequential per file or round-robin across files
+        let mut order: Vec<(usize, usize)> = Vec::new(); // (file_idx, local_chunk_idx)
+        if cfg.interleave_files {
+            let mut rr = 0usize;
+            loop {
+                let mut appended = false;
+                for (fi, tf) in tmp_files.iter().enumerate() {
+                    if rr < tf.chunks.len() {
+                        order.push((fi, rr));
+                        appended = true;
+                    }
+                }
+                if !appended {
+                    break;
+                }
+                rr += 1;
+            }
+        } else {
+            for (fi, tf) in tmp_files.iter().enumerate() {
+                for ci in 0..tf.chunks.len() {
+                    order.push((fi, ci));
+                }
+            }
+        }
+
+        // Build final buffers, manifest file entries with global idx, and Merkle list
+        let mut chunk_buffers: Vec<Vec<u8>> = Vec::with_capacity(order.len());
+        let mut all_chunk_hashes = Vec::with_capacity(order.len());
+        let mut file_entries: Vec<FileEntry> = tmp_files
+            .iter()
+            .map(|tf| FileEntry {
+                rel_path: tf.rel_path.clone(),
+                size: tf.size,
+                chunks: Vec::new(),
+            })
+            .collect();
+        let mut next_idx: u64 = 0;
+        for (fi, ci) in order {
+            let tc = &tmp_files[fi].chunks[ci];
+            // Preserve original content order for Merkle by recomputing from buffer
+            all_chunk_hashes.push(blake3::hash(&tc.buf));
+            chunk_buffers.push(tc.buf.clone());
+            file_entries[fi].chunks.push(ChunkRef {
+                idx: next_idx,
+                file_offset: tc.file_offset,
+                len: tc.len,
+                hash_hex: tc.hash_hex.clone(),
+            });
+            next_idx += 1;
+        }
+
+        // 3) Merkle root over final order
         let merkle_root_hex = merkle::root(&all_chunk_hashes).to_hex().to_string();
 
         // 4) Compute RS parity per stripe and write volumes (round-robin placement)
@@ -169,7 +221,7 @@ impl Encoder {
             stripe_k: cfg.stripe_k,
             parity_pct: cfg.parity_pct,
             total_bytes,
-            total_chunks: next_chunk_idx,
+            total_chunks: next_idx,
             files: file_entries,
             merkle_root_hex,
             parity_dir: output.to_string_lossy().to_string(),

--- a/parx-core/tests/encode_smoke.rs
+++ b/parx-core/tests/encode_smoke.rs
@@ -20,6 +20,7 @@ fn encode_small_dataset_and_verify_manifest_merkle() {
         volumes: 2,
         outer_group: 0,
         outer_parity: 0,
+        interleave_files: false,
     };
     let manifest = Encoder::encode(&root, &out, &cfg).unwrap();
 

--- a/parx-core/tests/verify_repair.rs
+++ b/parx-core/tests/verify_repair.rs
@@ -21,6 +21,7 @@ fn verify_then_repair_simple_corruption() {
         volumes: 2,
         outer_group: 0,
         outer_parity: 0,
+        interleave_files: false,
     };
     let manifest = Encoder::encode(&root, &out, &cfg).unwrap();
 

--- a/scripts/enable_required_signatures.sh
+++ b/scripts/enable_required_signatures.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: scripts/enable_required_signatures.sh [OWNER] [REPO] [BRANCH]
+
+OWNER=${1:-}
+REPO=${2:-}
+BR=${3:-main}
+
+if [[ -z "${OWNER}" || -z "${REPO}" ]]; then
+  url=$(git remote get-url origin 2>/dev/null || true)
+  if [[ -z "$url" ]]; then
+    echo "Error: provide OWNER REPO or run in a git repo with an 'origin' remote." >&2
+    exit 1
+  fi
+  owner_repo=$(sed -E 's#.*github.com[:/ ]([^/]+/[^/.]+)(\\.git)?$#\1#' <<<"$url")
+  OWNER="${owner_repo%/*}"
+  REPO="${owner_repo#*/}"
+fi
+
+gh api -X POST repos/$OWNER/$REPO/branches/$BR/protection/required_signatures >/dev/null
+echo "Required signed commits enabled on $OWNER/$REPO:$BR"
+

--- a/scripts/update_required_checks.sh
+++ b/scripts/update_required_checks.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: scripts/update_required_checks.sh [OWNER] [REPO] [BRANCH]
+
+OWNER=${1:-}
+REPO=${2:-}
+BR=${3:-main}
+
+if [[ -z "${OWNER}" || -z "${REPO}" ]]; then
+  url=$(git remote get-url origin 2>/dev/null || true)
+  if [[ -z "$url" ]]; then
+    echo "Error: provide OWNER REPO or run in a git repo with an 'origin' remote." >&2
+    exit 1
+  fi
+  owner_repo=$(sed -E 's#.*github.com[:/ ]([^/]+/[^/.]+)(\\.git)?$#\1#' <<<"$url")
+  OWNER="${owner_repo%/*}"
+  REPO="${owner_repo#*/}"
+fi
+
+echo "Updating required status checks for $OWNER/$REPO:$BR"
+
+# Desired contexts (must match job/check names exactly)
+contexts=(
+  "fmt"
+  "clippy"
+  "tests"
+  "cargo-deny"
+  "Analyze (rust)"
+)
+
+# Build JSON array of contexts
+ctx_json=$(printf '%s\n' "${contexts[@]}" | jq -Rcs 'split("\n") | map(select(length>0))')
+
+json=$(jq -n --argjson contexts "$ctx_json" '{
+  required_status_checks: { strict: true, contexts: $contexts },
+  enforce_admins: true,
+  required_pull_request_reviews: { required_approving_review_count: 1 },
+  restrictions: null,
+  allow_force_pushes: false,
+  allow_deletions: false,
+  required_linear_history: true
+}')
+
+printf '%s' "$json" | gh api -X PUT repos/$OWNER/$REPO/branches/$BR/protection -H "Accept: application/vnd.github+json" --input -
+echo
+echo "Done. Note: ensure jobs exist before making them required."
+


### PR DESCRIPTION
- core/cli: add --interleave-files to round-robin chunks across files per stripe\n- docs: README quick start fix; roadmap adds unbiased benchmark plan\n- ci: add branch-protection-guard workflow to detect drift and open issue\n- scripts: update_required_checks.sh and enable_required_signatures.sh\n\nThis introduces an opt-in interleave mode to improve resilience against full-file loss. CI and protections are aligned to avoid future policy drift.\n\nPlease review interleaving semantics and README wording.\n