### PR TITLE
path-safety: enforce policy in repair; add symlink tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,13 @@ what quality checks to run, and the licensing terms for contributions.
 
 - Rust: stable toolchain (install via [rustup](https://rustup.rs))
 - Build everything:
+
   ```bash
   cargo build --workspace
   ```
+
 - Run tests:
+
   ```bash
   cargo test --workspace
   ```

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-ParXive
+# ParXive
 
 Copyright (c) 2025 ParXive contributors
 

--- a/README.md
+++ b/README.md
@@ -106,33 +106,34 @@ Dual-licensed under **MIT** and **Apache-2.0** — pick one or both. See `LICENS
 
 1) Create parity for a dataset with moderate protection
 
-```
-parx create \
-  --parity 35 \
-  --stripe-k 16 \
-  --chunk-size 1048576 \
-  --output .parx \
-  --volume-sizes 16M,16M,16M \
-  ./my_data
+    ```bash
+    parx create \
+      --parity 35 \
+      --stripe-k 16 \
+      --chunk-size 1048576 \
+      --output .parx \
+      --volume-sizes 16M,16M,16M \
+      ./my_data
 
-parx quickcheck .parx
-parx paritycheck .parx
-```
+    parx quickcheck .parx
+    parx paritycheck .parx
+    ```
 
 2) Small dataset (fast) with 50% parity and small chunks
 
-```
-parx create --parity 50 --stripe-k 8 --chunk-size 65536 --output .parx --volume-sizes 2M,2M,2M ./demo_data
-parx verify .parx/manifest.json .
-```
+    ```bash
+    parx create --parity 50 --stripe-k 8 --chunk-size 65536 --output .parx --volume-sizes 2M,2M,2M ./demo_data
+    parx verify .parx/manifest.json .
+    ```
 
 3) Diagnose a volume file
 
-```
-parx outer-decode .parx/vol-000.parxv
-```
+    ```bash
+    parx outer-decode .parx/vol-000.parxv
+    ```
 
 Notes
+
 - ParXive stores a compressed, CRC-protected index at the end of each volume file.
 - The manifest includes per-chunk BLAKE3 hashes and a dataset Merkle root.
 - Outer RS (parity-of-parity) is planned; GPU acceleration is optional.
@@ -148,7 +149,7 @@ ParXive is library-first. The `parx-core` crate exposes a clean API for encoding
 
 Add to your `Cargo.toml`:
 
-```
+```bash
 [dependencies]
 parx-core = { path = "./parx-core" } # use crates.io release when available
 ```
@@ -177,13 +178,14 @@ fn main() -> anyhow::Result<()> {
 ```
 
 Upcoming APIs (Stage 2):
+
 - Verify: re-hash and validate the manifest and Merkle root.
 - Audit: compute stripe health and repairability.
 - Repair: reconstruct missing chunks and write atomically.
 
 ### Building from source
 
-```
+```bash
 cargo build --release -p parx-cli
 cargo test --workspace
 ```
@@ -198,6 +200,7 @@ cargo test --workspace
 ### Adopting ParXive in other languages
 
 ParXive aims for broad adoption. We will provide:
+
 - A stable C-compatible FFI for `parx-core` (encode/verify/audit/repair).
 - Bindings and examples for popular ecosystems (Python, Node.js, Go, etc.).
 - Packaging guidance and policies to meet inclusion guidelines in official registries.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,13 @@
 # Security Policy
 
 Supported Versions
+
 - Pre-1.0.0: latest minor release only (0.x.y). Older minors may receive critical fixes at our discretion.
 - Post-1.0.0 (future): semantic versioning with security backports to supported minors.
 
 Report a Vulnerability
-- Preferred: open a GitHub Security Advisory (if available on the public repo), or email: security@please-set-domain.example
+
+- Preferred: open a GitHub Security Advisory (if available on the public repo), or email: <security@please-set-domain.example>
 - Alternative: create a private issue titled "[SECURITY] ...". Do not include exploit details in public issues.
 - Please provide:
   - Affected version(s) and environment
@@ -14,10 +16,12 @@ Report a Vulnerability
   - Your disclosure preference and a contact
 
 Coordinated Disclosure
+
 - We aim to acknowledge within 3 business days and provide a triage result within 7 business days.
 - We prefer a 90-day disclosure window (can be shorter/longer by mutual agreement based on impact and fix readiness).
 
 Scope & Threat Model (initial)
+
 - Inputs are untrusted: manifest, indices, trailers, CLI arguments, and file paths
 - Denial of service and memory safety concerns
 - Path traversal, symlink escapes, and unsafe file writes
@@ -25,14 +29,15 @@ Scope & Threat Model (initial)
 - Concurrency races (repair operations) and partial writes
 
 Current Mitigations
+
 - Strict path validation: reject absolute and parent traversal; default do not follow symlinks; override requires containment under root
 - Index parsing: CRC verification and bounded decompression; entry/size limits
 - Repairs: advisory locking (global and per-file), backups by default, fsync and atomic rename when possible
 - Pre-commit/CI: clippy -D warnings, tests, and (future) cargo-deny; fuzzing planned for parsers
 
 Hardening Roadmap
+
 - Fuzz parsers (trailer/index/manifest) and RS boundaries
 - cargo-deny for dependency audit; SBOM generation
 - CI matrix across platforms and MSRV policy
 - Optional signing of manifests/indices
-

--- a/parx-cli/src/main.rs
+++ b/parx-cli/src/main.rs
@@ -332,8 +332,9 @@ fn run() -> Result<()> {
             }
         }
 
-        Commands::Repair { json, follow_symlinks: _, manifest, root } => {
-            let rr = parx_core::repair::repair(&manifest, &root)?;
+        Commands::Repair { json, follow_symlinks, manifest, root } => {
+            let policy = parx_core::path_safety::PathPolicy { follow_symlinks };
+            let rr = parx_core::repair::repair_with_policy(&manifest, &root, policy)?;
             if json {
                 println!("{}", serde_json::to_string(&rr)?);
             }

--- a/parx-core/tests/path_safety.rs
+++ b/parx-core/tests/path_safety.rs
@@ -1,0 +1,105 @@
+use std::fs::{self, File};
+use std::io::Write;
+// no extra imports
+
+#[cfg(target_family = "unix")]
+fn symlink_dir<P: AsRef<std::path::Path>, Q: AsRef<std::path::Path>>(
+    src: P,
+    dst: Q,
+) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(src, dst)
+}
+
+#[test]
+fn verify_rejects_symlink_by_default_allows_with_flag_when_contained() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("root");
+    let out = tmp.path().join("out");
+    fs::create_dir_all(root.join("target")).unwrap();
+    fs::create_dir_all(&out).unwrap();
+
+    // Create a simple file under target
+    let p = root.join("target/file.txt");
+    let mut f = File::create(&p).unwrap();
+    writeln!(f, "hello").unwrap();
+
+    // Encode manifest (no symlinks included during encode)
+    let cfg = parx_core::encode::EncoderConfig {
+        chunk_size: 1 << 10,
+        stripe_k: 2,
+        parity_pct: 50,
+        volumes: 1,
+        outer_group: 0,
+        outer_parity: 0,
+        interleave_files: false,
+    };
+    let mut manifest = parx_core::encode::Encoder::encode(&root, &out, &cfg).unwrap();
+
+    // Re-point the single file entry to a symlinked path safe/ that targets target/
+    // Create the symlink inside root
+    let safe = root.join("safe");
+    symlink_dir(root.join("target"), &safe).unwrap();
+
+    // Modify manifest rel_path
+    assert_eq!(manifest.files.len(), 1);
+    manifest.files[0].rel_path = "safe/file.txt".to_string();
+    let mpath = out.join("manifest.json");
+    let mut mf = File::create(&mpath).unwrap();
+    mf.write_all(serde_json::to_string_pretty(&manifest).unwrap().as_bytes()).unwrap();
+
+    // Default policy: symlink should be rejected
+    let err = parx_core::verify::verify(&mpath, &root).expect_err("expected error");
+    let msg = format!("{:#}", err);
+    assert!(msg.contains("symlink"), "unexpected error: {}", msg);
+
+    // With follow_symlinks: allowed if contained under root
+    let policy = parx_core::path_safety::PathPolicy { follow_symlinks: true };
+    let rep = parx_core::verify::verify_with_policy(&mpath, &root, policy).unwrap();
+    assert!(rep.merkle_ok);
+}
+
+#[test]
+fn verify_blocks_symlink_escape_even_when_following() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("root");
+    let out = tmp.path().join("out");
+    fs::create_dir_all(root.join("target")).unwrap();
+    fs::create_dir_all(&out).unwrap();
+
+    // Real file under root/target
+    let p = root.join("target/file.txt");
+    let mut f = File::create(&p).unwrap();
+    writeln!(f, "hello").unwrap();
+
+    // Encode
+    let cfg = parx_core::encode::EncoderConfig {
+        chunk_size: 1 << 10,
+        stripe_k: 2,
+        parity_pct: 50,
+        volumes: 1,
+        outer_group: 0,
+        outer_parity: 0,
+        interleave_files: false,
+    };
+    let mut manifest = parx_core::encode::Encoder::encode(&root, &out, &cfg).unwrap();
+
+    // Create a symlink that escapes: root/evil -> root/.. (the parent tempdir)
+    let parent = root.parent().unwrap();
+    let evil = root.join("evil");
+    symlink_dir(parent, &evil).unwrap();
+    // Place a file outside the root so canonicalization succeeds, then we fail containment
+    let outside = parent.join("outside.txt");
+    let mut of = File::create(&outside).unwrap();
+    writeln!(of, "outside").unwrap();
+    // Point manifest to evil/outside.txt (escapes root)
+    manifest.files[0].rel_path = "evil/outside.txt".to_string();
+    let mpath = out.join("manifest.json");
+    let mut mf = File::create(&mpath).unwrap();
+    mf.write_all(serde_json::to_string_pretty(&manifest).unwrap().as_bytes()).unwrap();
+
+    let policy = parx_core::path_safety::PathPolicy { follow_symlinks: true };
+    let err = parx_core::verify::verify_with_policy(&mpath, &root, policy)
+        .expect_err("expected escape error");
+    let msg = format!("{:#}", err);
+    assert!(msg.contains("escapes root"));
+}


### PR DESCRIPTION
- Wire CLI --follow-symlinks into repair via repair_with_policy\n- Keep default behavior: do not follow symlinks; contain paths under root\n- Add tests: reject symlink by default; allow contained symlink with flag; block escapes even with flag\n\nNo functional changes to encode path; WalkDir already avoids following symlinks.\nClippy clean; tests added and passing.