### PR TITLE
bench: local-only matrix runner + docs + Make targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,13 @@ what quality checks to run, and the licensing terms for contributions.
 
 - Rust: stable toolchain (install via [rustup](https://rustup.rs))
 - Build everything:
+
   ```bash
   cargo build --workspace
   ```
+
 - Run tests:
+
   ```bash
   cargo test --workspace
   ```

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all debug release fmt clippy test
+.PHONY: all debug release fmt clippy test bench-local bench-matrix
 all: release
 debug: ; cargo build
 release: ; cargo build --release
@@ -6,3 +6,10 @@ fmt: ; cargo fmt
 clippy: ; cargo clippy -- -D warnings
 test: ; cargo test -- --nocapture
 
+# Local-only quick smoke benchmark (heavy): refuses to run in CI
+bench-local:
+	./scripts/bench_repair_smoke.sh || true
+
+# Local-only full matrix benchmark (heavy): refuses to run in CI
+bench-matrix:
+	./scripts/bench_matrix_local.sh || true

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-ParXive
+# ParXive
 
 Copyright (c) 2025 ParXive contributors
 

--- a/README.md
+++ b/README.md
@@ -106,33 +106,34 @@ Dual-licensed under **MIT** and **Apache-2.0** — pick one or both. See `LICENS
 
 1) Create parity for a dataset with moderate protection
 
-```
-parx create \
-  --parity 35 \
-  --stripe-k 16 \
-  --chunk-size 1048576 \
-  --output .parx \
-  --volume-sizes 16M,16M,16M \
-  ./my_data
+    ```bash
+    parx create \
+      --parity 35 \
+      --stripe-k 16 \
+      --chunk-size 1048576 \
+      --output .parx \
+      --volume-sizes 16M,16M,16M \
+      ./my_data
 
-parx quickcheck .parx
-parx paritycheck .parx
-```
+    parx quickcheck .parx
+    parx paritycheck .parx
+    ```
 
 2) Small dataset (fast) with 50% parity and small chunks
 
-```
-parx create --parity 50 --stripe-k 8 --chunk-size 65536 --output .parx --volume-sizes 2M,2M,2M ./demo_data
-parx verify .parx/manifest.json .
-```
+    ```bash
+    parx create --parity 50 --stripe-k 8 --chunk-size 65536 --output .parx --volume-sizes 2M,2M,2M ./demo_data
+    parx verify .parx/manifest.json .
+    ```
 
 3) Diagnose a volume file
 
-```
-parx outer-decode .parx/vol-000.parxv
-```
+    ```bash
+    parx outer-decode .parx/vol-000.parxv
+    ```
 
 Notes
+
 - ParXive stores a compressed, CRC-protected index at the end of each volume file.
 - The manifest includes per-chunk BLAKE3 hashes and a dataset Merkle root.
 - Outer RS (parity-of-parity) is planned; GPU acceleration is optional.
@@ -148,7 +149,7 @@ ParXive is library-first. The `parx-core` crate exposes a clean API for encoding
 
 Add to your `Cargo.toml`:
 
-```
+```bash
 [dependencies]
 parx-core = { path = "./parx-core" } # use crates.io release when available
 ```
@@ -177,13 +178,14 @@ fn main() -> anyhow::Result<()> {
 ```
 
 Upcoming APIs (Stage 2):
+
 - Verify: re-hash and validate the manifest and Merkle root.
 - Audit: compute stripe health and repairability.
 - Repair: reconstruct missing chunks and write atomically.
 
 ### Building from source
 
-```
+```bash
 cargo build --release -p parx-cli
 cargo test --workspace
 ```
@@ -198,6 +200,7 @@ cargo test --workspace
 ### Adopting ParXive in other languages
 
 ParXive aims for broad adoption. We will provide:
+
 - A stable C-compatible FFI for `parx-core` (encode/verify/audit/repair).
 - Bindings and examples for popular ecosystems (Python, Node.js, Go, etc.).
 - Packaging guidance and policies to meet inclusion guidelines in official registries.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,13 @@
 # Security Policy
 
 Supported Versions
+
 - Pre-1.0.0: latest minor release only (0.x.y). Older minors may receive critical fixes at our discretion.
 - Post-1.0.0 (future): semantic versioning with security backports to supported minors.
 
 Report a Vulnerability
-- Preferred: open a GitHub Security Advisory (if available on the public repo), or email: security@please-set-domain.example
+
+- Preferred: open a GitHub Security Advisory (if available on the public repo), or email: <security@please-set-domain.example>
 - Alternative: create a private issue titled "[SECURITY] ...". Do not include exploit details in public issues.
 - Please provide:
   - Affected version(s) and environment
@@ -14,10 +16,12 @@ Report a Vulnerability
   - Your disclosure preference and a contact
 
 Coordinated Disclosure
+
 - We aim to acknowledge within 3 business days and provide a triage result within 7 business days.
 - We prefer a 90-day disclosure window (can be shorter/longer by mutual agreement based on impact and fix readiness).
 
 Scope & Threat Model (initial)
+
 - Inputs are untrusted: manifest, indices, trailers, CLI arguments, and file paths
 - Denial of service and memory safety concerns
 - Path traversal, symlink escapes, and unsafe file writes
@@ -25,14 +29,15 @@ Scope & Threat Model (initial)
 - Concurrency races (repair operations) and partial writes
 
 Current Mitigations
+
 - Strict path validation: reject absolute and parent traversal; default do not follow symlinks; override requires containment under root
 - Index parsing: CRC verification and bounded decompression; entry/size limits
 - Repairs: advisory locking (global and per-file), backups by default, fsync and atomic rename when possible
 - Pre-commit/CI: clippy -D warnings, tests, and (future) cargo-deny; fuzzing planned for parsers
 
 Hardening Roadmap
+
 - Fuzz parsers (trailer/index/manifest) and RS boundaries
 - cargo-deny for dependency audit; SBOM generation
 - CI matrix across platforms and MSRV policy
 - Optional signing of manifests/indices
-

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -36,7 +36,18 @@ Anti-bias measures
 - Predefine scoring and plots before running;
 - Document any anomalies and reruns.
 
-Next Steps
-- Scaffold `bench/` harness and minimal dataset generator.
-- Add CI job to lint/run a tiny smoke benchmark (short dataset) just for script integrity.
+Local-only runners
+- `scripts/bench_repair_smoke.sh` — quick sanity: create → delete subset → repair; asserts dataset hash matches baseline via `parx hashcat`.
+- `scripts/bench_matrix_local.sh` — matrix over scenarios and parameters (K, parity%, chunk size, interleave). Writes JSONL to `_tgt/bench-results/bench-<timestamp>.jsonl`.
 
+Usage (local)
+- `make bench-local`
+- `make bench-matrix`
+- Customize via env, e.g.:
+  `K_SET="8 16" PARITY_PCT_SET="25 50" CHUNK_SET="65536 1048576" INTERLEAVE_SET="off on" SCENARIOS="many-small mixed" ./scripts/bench_matrix_local.sh`
+
+Hash catalogue
+- `parx hashcat <root>` emits per-file BLAKE3 and a deterministic dataset hash; use `--hash-only` for baseline/post comparisons.
+
+CI policy
+- Heavy benchmarks are guarded and refuse to run in CI (`CI`/`GITHUB_ACTIONS`).

--- a/parx-cli/src/main.rs
+++ b/parx-cli/src/main.rs
@@ -332,8 +332,9 @@ fn run() -> Result<()> {
             }
         }
 
-        Commands::Repair { json, follow_symlinks: _, manifest, root } => {
-            let rr = parx_core::repair::repair(&manifest, &root)?;
+        Commands::Repair { json, follow_symlinks, manifest, root } => {
+            let policy = parx_core::path_safety::PathPolicy { follow_symlinks };
+            let rr = parx_core::repair::repair_with_policy(&manifest, &root, policy)?;
             if json {
                 println!("{}", serde_json::to_string(&rr)?);
             }

--- a/parx-core/src/repair.rs
+++ b/parx-core/src/repair.rs
@@ -15,11 +15,10 @@ pub struct RepairReport {
     pub failed_chunks: u64,
 }
 
-fn collect_parity_shards(
-    parity_dir: &Path,
-    chunk_size: usize,
-) -> Result<HashMap<u32, Vec<Vec<u8>>>> {
-    let mut map: HashMap<u32, Vec<Vec<u8>>> = HashMap::new();
+type ParityMap = HashMap<u32, Vec<(usize, Vec<u8>)>>;
+
+fn collect_parity_shards(parity_dir: &Path, chunk_size: usize) -> Result<ParityMap> {
+    let mut map: ParityMap = HashMap::new();
     if !parity_dir.exists() {
         return Ok(map);
     }
@@ -36,7 +35,7 @@ fn collect_parity_shards(
                 if buf.len() < chunk_size {
                     buf.resize(chunk_size, 0);
                 }
-                map.entry(e.stripe).or_default().push(buf);
+                map.entry(e.stripe).or_default().push((e.parity_idx as usize, buf));
             }
         }
     }
@@ -67,11 +66,13 @@ pub fn repair_with_policy(
     let rs = RsCodec::new(k, m).context("init RS")?;
     let parity_map = collect_parity_shards(Path::new(&mf.parity_dir), mf.chunk_size)?;
 
-    // Build map idx -> (safe_path, offset, len)
+    // Build map idx -> (safe_path, offset, len) and record target file sizes
     let mut idx_map: HashMap<u64, (PathBuf, u64, u32)> = HashMap::new();
+    let mut file_sizes: HashMap<PathBuf, u64> = HashMap::new();
     for fe in &mf.files {
         let safe = validate_path(root, Path::new(&fe.rel_path), policy)
             .with_context(|| format!("validate path {:?}", fe.rel_path))?;
+        file_sizes.insert(safe.clone(), fe.size);
         for ch in &fe.chunks {
             idx_map.insert(ch.idx, (safe.clone(), ch.file_offset, ch.len));
         }
@@ -101,6 +102,11 @@ pub fn repair_with_policy(
                 let data_i = (idx % k as u64) as usize;
                 to_repair.entry(stripe).or_default().push(data_i);
             }
+        } else {
+            // File missing: mark this data shard as missing for reconstruction
+            let stripe = idx / k as u64;
+            let data_i = (idx % k as u64) as usize;
+            to_repair.entry(stripe).or_default().push(data_i);
         }
     }
 
@@ -130,8 +136,10 @@ pub fn repair_with_policy(
             }
         }
         // M parity
-        let mut shards: Vec<Option<Vec<u8>>> = Vec::with_capacity(k + m);
-        shards.extend(data_bufs);
+        let mut shards: Vec<Option<Vec<u8>>> = vec![None; k + m];
+        for (i, db) in data_bufs.into_iter().enumerate() {
+            shards[i] = db;
+        }
         let mut parity = Vec::new();
         if let Some(v) = parity_map.get(&(stripe as u32)) {
             parity = v.clone();
@@ -140,8 +148,10 @@ pub fn repair_with_policy(
             failed_chunks += missing.len() as u64;
             continue;
         }
-        for pbuf in parity.iter().take(m) {
-            shards.push(Some(pbuf.clone()));
+        for (pi, pbuf) in parity.into_iter() {
+            if pi < m {
+                shards[k + pi] = Some(pbuf);
+            }
         }
 
         if rs.reconstruct(&mut shards).is_ok() {
@@ -174,13 +184,26 @@ pub fn repair_with_policy(
         let parent = path.parent().unwrap_or(Path::new("."));
         let tmp = parent.join(format!("{}.parx.tmp", path.file_name().unwrap().to_string_lossy()));
         let atomic_res = (|| -> Result<()> {
-            let mut orig = std::fs::read(&path).with_context(|| format!("read {:?}", path))?;
+            let mut orig = match std::fs::read(&path) {
+                Ok(b) => b,
+                Err(_) => {
+                    // Recreate missing file buffer sized to manifest size (or grow on writes)
+                    let sz = *file_sizes.get(&path).unwrap_or(&0u64) as usize;
+                    vec![0u8; sz]
+                }
+            };
             for (off, data) in &edits {
                 let off = *off as usize;
                 if off + data.len() > orig.len() {
                     orig.resize(off + data.len(), 0);
                 }
                 orig[off..off + data.len()].copy_from_slice(data);
+            }
+            // Truncate back to manifest-declared file size if known
+            if let Some(sz) = file_sizes.get(&path) {
+                if orig.len() > *sz as usize {
+                    orig.truncate(*sz as usize);
+                }
             }
             {
                 let mut tf = std::fs::OpenOptions::new()
@@ -196,7 +219,13 @@ pub fn repair_with_policy(
         })();
         if atomic_res.is_err() {
             // Fallback to in-place with advisory lock
-            if let Ok(mut f) = std::fs::OpenOptions::new().read(true).write(true).open(&path) {
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .read(true)
+                .write(true)
+                .truncate(false)
+                .open(&path)
+            {
                 let _ = f.try_lock_exclusive();
                 for (off, data) in &edits {
                     if f.seek(SeekFrom::Start(*off)).is_ok() {

--- a/parx-core/tests/path_safety.rs
+++ b/parx-core/tests/path_safety.rs
@@ -1,0 +1,105 @@
+use std::fs::{self, File};
+use std::io::Write;
+// no extra imports
+
+#[cfg(target_family = "unix")]
+fn symlink_dir<P: AsRef<std::path::Path>, Q: AsRef<std::path::Path>>(
+    src: P,
+    dst: Q,
+) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(src, dst)
+}
+
+#[test]
+fn verify_rejects_symlink_by_default_allows_with_flag_when_contained() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("root");
+    let out = tmp.path().join("out");
+    fs::create_dir_all(root.join("target")).unwrap();
+    fs::create_dir_all(&out).unwrap();
+
+    // Create a simple file under target
+    let p = root.join("target/file.txt");
+    let mut f = File::create(&p).unwrap();
+    writeln!(f, "hello").unwrap();
+
+    // Encode manifest (no symlinks included during encode)
+    let cfg = parx_core::encode::EncoderConfig {
+        chunk_size: 1 << 10,
+        stripe_k: 2,
+        parity_pct: 50,
+        volumes: 1,
+        outer_group: 0,
+        outer_parity: 0,
+        interleave_files: false,
+    };
+    let mut manifest = parx_core::encode::Encoder::encode(&root, &out, &cfg).unwrap();
+
+    // Re-point the single file entry to a symlinked path safe/ that targets target/
+    // Create the symlink inside root
+    let safe = root.join("safe");
+    symlink_dir(root.join("target"), &safe).unwrap();
+
+    // Modify manifest rel_path
+    assert_eq!(manifest.files.len(), 1);
+    manifest.files[0].rel_path = "safe/file.txt".to_string();
+    let mpath = out.join("manifest.json");
+    let mut mf = File::create(&mpath).unwrap();
+    mf.write_all(serde_json::to_string_pretty(&manifest).unwrap().as_bytes()).unwrap();
+
+    // Default policy: symlink should be rejected
+    let err = parx_core::verify::verify(&mpath, &root).expect_err("expected error");
+    let msg = format!("{:#}", err);
+    assert!(msg.contains("symlink"), "unexpected error: {}", msg);
+
+    // With follow_symlinks: allowed if contained under root
+    let policy = parx_core::path_safety::PathPolicy { follow_symlinks: true };
+    let rep = parx_core::verify::verify_with_policy(&mpath, &root, policy).unwrap();
+    assert!(rep.merkle_ok);
+}
+
+#[test]
+fn verify_blocks_symlink_escape_even_when_following() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("root");
+    let out = tmp.path().join("out");
+    fs::create_dir_all(root.join("target")).unwrap();
+    fs::create_dir_all(&out).unwrap();
+
+    // Real file under root/target
+    let p = root.join("target/file.txt");
+    let mut f = File::create(&p).unwrap();
+    writeln!(f, "hello").unwrap();
+
+    // Encode
+    let cfg = parx_core::encode::EncoderConfig {
+        chunk_size: 1 << 10,
+        stripe_k: 2,
+        parity_pct: 50,
+        volumes: 1,
+        outer_group: 0,
+        outer_parity: 0,
+        interleave_files: false,
+    };
+    let mut manifest = parx_core::encode::Encoder::encode(&root, &out, &cfg).unwrap();
+
+    // Create a symlink that escapes: root/evil -> root/.. (the parent tempdir)
+    let parent = root.parent().unwrap();
+    let evil = root.join("evil");
+    symlink_dir(parent, &evil).unwrap();
+    // Place a file outside the root so canonicalization succeeds, then we fail containment
+    let outside = parent.join("outside.txt");
+    let mut of = File::create(&outside).unwrap();
+    writeln!(of, "outside").unwrap();
+    // Point manifest to evil/outside.txt (escapes root)
+    manifest.files[0].rel_path = "evil/outside.txt".to_string();
+    let mpath = out.join("manifest.json");
+    let mut mf = File::create(&mpath).unwrap();
+    mf.write_all(serde_json::to_string_pretty(&manifest).unwrap().as_bytes()).unwrap();
+
+    let policy = parx_core::path_safety::PathPolicy { follow_symlinks: true };
+    let err = parx_core::verify::verify_with_policy(&mpath, &root, policy)
+        .expect_err("expected escape error");
+    let msg = format!("{:#}", err);
+    assert!(msg.contains("escapes root"));
+}

--- a/scripts/bench_matrix_local.sh
+++ b/scripts/bench_matrix_local.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local-only benchmark matrix runner.
+# Generates datasets, encodes with various K/M/chunk/interleave settings,
+# simulates damage, repairs, and validates via `parx hashcat`.
+# Outputs JSONL results to _tgt/bench-results/bench-<timestamp>.jsonl
+
+if [[ "${GITHUB_ACTIONS:-}" == "true" || "${CI:-}" == "true" ]]; then
+  echo "This benchmark matrix is designed for local runs only. Skipping in CI." >&2
+  exit 2
+fi
+
+ROOT_BASE="${1:-_tgt/bench-matrix-root}"
+OUT_BASE="${2:-_tgt/bench-matrix-out}"
+RES_DIR="${3:-_tgt/bench-results}"
+
+mkdir -p "$ROOT_BASE" "$OUT_BASE" "$RES_DIR"
+STAMP=$(date +%Y%m%d-%H%M%S)
+RESULTS="$RES_DIR/bench-$STAMP.jsonl"
+
+# Parameter sets (override via env vars)
+K_SET=(${K_SET:-8 16})
+PARITY_PCT_SET=(${PARITY_PCT_SET:-25 50})
+CHUNK_SET=(${CHUNK_SET:-65536 1048576}) # 64 KiB, 1 MiB
+INTERLEAVE_SET=(${INTERLEAVE_SET:-off on})
+SCENARIOS=(${SCENARIOS:-many-small many-large single mixed})
+
+# Scenario sizes (override via env): default is modest, adjust locally as needed
+SMALL_COUNT=${SMALL_COUNT:-1000}      # many-small number of files
+SMALL_SIZE=${SMALL_SIZE:-4096}        # bytes per small file
+LARGE_COUNT=${LARGE_COUNT:-4}         # many-large files count
+LARGE_SIZE=${LARGE_SIZE:-16777216}    # 16 MiB per large file
+SINGLE_SIZE=${SINGLE_SIZE:-67108864}  # 64 MiB single file
+MIXED_SMALL=${MIXED_SMALL:-200}       # mixed: small files count
+MIXED_LARGE=${MIXED_LARGE:-2}         # mixed: large files count
+
+ts_ms() {
+  # millisecond timestamp
+  if date +%s%3N >/dev/null 2>&1; then
+    date +%s%3N
+  else
+    python3 - <<'PY'
+import time
+print(int(time.time()*1000))
+PY
+  fi
+}
+
+gen_dataset() {
+  local scenario="$1"; local root="$2";
+  rm -rf "$root"; mkdir -p "$root"
+  case "$scenario" in
+    many-small)
+      mkdir -p "$root/s"
+      for ((i=1;i<=SMALL_COUNT;i++)); do
+        head -c "$SMALL_SIZE" </dev/urandom >"$root/s/f$(printf %06d "$i").bin"
+      done
+      ;;
+    many-large)
+      mkdir -p "$root/l"
+      for ((i=1;i<=LARGE_COUNT;i++)); do
+        head -c "$LARGE_SIZE" </dev/urandom >"$root/l/L$(printf %03d "$i").bin"
+      done
+      ;;
+    single)
+      head -c "$SINGLE_SIZE" </dev/urandom >"$root/single.bin"
+      ;;
+    mixed)
+      mkdir -p "$root/s" "$root/l" "$root/m"
+      for ((i=1;i<=MIXED_SMALL;i++)); do
+        head -c "$SMALL_SIZE" </dev/urandom >"$root/s/s$(printf %05d "$i").bin"
+      done
+      for ((i=1;i<=MIXED_LARGE;i++)); do
+        head -c "$LARGE_SIZE" </dev/urandom >"$root/l/L$(printf %03d "$i").bin"
+      done
+      # a few medium files
+      for i in 1 2 3; do
+        head -c $((SMALL_SIZE*128)) </dev/urandom >"$root/m/M$i.bin"
+      done
+      ;;
+    *) echo "Unknown scenario: $scenario" >&2; return 1;;
+  esac
+}
+
+damage_dataset() {
+  local scenario="$1"; local root="$2";
+  case "$scenario" in
+    many-small)
+      # delete ~1% of files
+      find "$root/s" -type f | shuf -n $((SMALL_COUNT/100 + 1)) | xargs -r rm -f --
+      ;;
+    many-large)
+      # delete one large file
+      rm -f -- "$(find "$root/l" -type f | head -n1)"
+      ;;
+    single)
+      # flip random 4 KiB region to simulate corruption
+      python3 - "$root/single.bin" <<'PY'
+import os,sys,random
+p=sys.argv[1]
+sz=os.path.getsize(p)
+off=max(0, random.randrange(max(1, sz-4096)))
+with open(p,'r+b') as f:
+  f.seek(off); f.write(os.urandom(4096))
+PY
+      ;;
+    mixed)
+      # delete a handful of small files
+      find "$root/s" -type f | shuf -n $((MIXED_SMALL/50 + 1)) | xargs -r rm -f --
+      ;;
+  esac
+}
+
+emit_result() {
+  local obj="$1"; echo "$obj" >>"$RESULTS"
+}
+
+echo "Writing results to: $RESULTS"
+
+for scenario in "${SCENARIOS[@]}"; do
+  for K in "${K_SET[@]}"; do
+    for PP in "${PARITY_PCT_SET[@]}"; do
+      for CHUNK in "${CHUNK_SET[@]}"; do
+        for IL in "${INTERLEAVE_SET[@]}"; do
+          ROOT="$ROOT_BASE/$scenario-K$K-P$PP-C$CHUNK-IL$IL"
+          OUT="$OUT_BASE/$scenario-K$K-P$PP-C$CHUNK-IL$IL"
+          rm -rf "$OUT"
+          gen_dataset "$scenario" "$ROOT"
+
+          BASE_JSON=$(cargo run -q -p parx-cli -- hashcat --json "$ROOT")
+          BASE_HASH=$(echo "$BASE_JSON" | jq -r .dataset_hash_hex)
+          TOTAL_BYTES=$(echo "$BASE_JSON" | jq -r .total_bytes)
+
+          ILOPTS=""; if [[ "$IL" == "on" ]]; then ILOPTS="--interleave-files"; fi
+
+          t0=$(ts_ms)
+          cargo run -q -p parx-cli -- create --parity "$PP" --stripe-k "$K" $ILOPTS --chunk-size "$CHUNK" --output "$OUT" --volume-sizes 64M,64M,64M "$ROOT"
+          t1=$(ts_ms)
+          enc_ms=$((t1 - t0))
+
+          # Parity bytes on disk
+          PARITY_BYTES=$(find "$OUT" -maxdepth 1 -name 'vol-*.parxv' -printf '%s\n' | awk '{s+=$1} END{print s+0}')
+
+          # Damage and repair
+          damage_dataset "$scenario" "$ROOT"
+          t2=$(ts_ms)
+          RJSON=$(cargo run -q -p parx-cli -- repair --json "$OUT/manifest.json" "$ROOT" || true)
+          t3=$(ts_ms)
+          rep_ms=$((t3 - t2))
+          repaired=$(echo "$RJSON" | jq -r '.repaired_chunks // 0' 2>/dev/null || echo 0)
+          failed=$(echo "$RJSON" | jq -r '.failed_chunks // 0' 2>/dev/null || echo 0)
+
+          POST_HASH=$(cargo run -q -p parx-cli -- hashcat --hash-only "$ROOT")
+          ok=$([[ "$BASE_HASH" == "$POST_HASH" ]] && echo true || echo false)
+
+          emit_result "$(jq -n \
+            --arg scenario "$scenario" \
+            --argjson k "$K" \
+            --argjson parity_pct "$PP" \
+            --argjson chunk "$CHUNK" \
+            --arg interleave "$IL" \
+            --arg base_hash "$BASE_HASH" \
+            --arg post_hash "$POST_HASH" \
+            --argjson total_bytes "$TOTAL_BYTES" \
+            --argjson parity_bytes "$PARITY_BYTES" \
+            --argjson encode_ms "$enc_ms" \
+            --argjson repair_ms "$rep_ms" \
+            --argjson repaired_chunks "$repaired" \
+            --argjson failed_chunks "$failed" \
+            --arg root "$ROOT" --arg out "$OUT" \
+            '{ts: now, scenario: $scenario, k: $k, parity_pct: $parity_pct, chunk: $chunk, interleave: $interleave, total_bytes: $total_bytes, parity_bytes: $parity_bytes, encode_ms: $encode_ms, repair_ms: $repair_ms, repaired_chunks: $repaired_chunks, failed_chunks: $failed_chunks, ok: ($base_hash==$post_hash), root: $root, out: $out, base_hash: $base_hash, post_hash: $post_hash}' )"
+          echo "[${scenario}] K=$K P=$PP C=$CHUNK IL=$IL => ok=$ok enc=${enc_ms}ms rep=${rep_ms}ms"
+        done
+      done
+    done
+  done
+done
+
+echo "Done. Results: $RESULTS"

--- a/scripts/bench_repair_smoke.sh
+++ b/scripts/bench_repair_smoke.sh
@@ -44,4 +44,8 @@ else
   echo "FAIL: Dataset hash mismatch after repair." >&2
   exit 1
 fi
-
+# Refuse to run in CI environments
+if [[ "${GITHUB_ACTIONS:-}" == "true" || "${CI:-}" == "true" ]]; then
+  echo "This benchmark is designed for local runs only. Skipping in CI." >&2
+  exit 2
+fi

--- a/scripts/bench_repair_smoke.sh
+++ b/scripts/bench_repair_smoke.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple smoke benchmark: create dataset, encode, delete a subset, repair, verify via hashcat
+
+ROOT=${1:-"_tgt/bench-dataset"}
+OUT=${2:-"_tgt/bench-out"}
+INTERLEAVE=${3:-"--interleave-files"}
+
+rm -rf "$ROOT" "$OUT"
+mkdir -p "$ROOT" "$OUT"
+
+echo "Generating dataset under $ROOT ..."
+mkdir -p "$ROOT/small" "$ROOT/large"
+for i in $(seq 1 100); do
+  printf "file %04d\n" "$i" > "$ROOT/small/s_$i.txt"
+done
+
+# Large files (~1 MiB each)
+dd if=/dev/zero of="$ROOT/large/L1.bin" bs=1M count=2 status=none
+dd if=/dev/zero of="$ROOT/large/L2.bin" bs=1M count=4 status=none
+
+echo "Baseline hash catalogue..."
+BASE_HASH=$(cargo run -q -p parx-cli -- hashcat --hash-only "$ROOT")
+echo "BASE: $BASE_HASH"
+
+echo "Encoding with parity..."
+time cargo run -q -p parx-cli -- create --parity 50 --stripe-k 8 $INTERLEAVE --chunk-size 65536 --output "$OUT" --volume-sizes 16M,16M,16M "$ROOT"
+
+echo "Simulating damage (delete 10 small files)..."
+for i in $(seq 1 10); do rm -f "$ROOT/small/s_$i.txt"; done
+
+echo "Repairing..."
+time cargo run -q -p parx-cli -- repair "$OUT/manifest.json" "$ROOT"
+
+echo "Post-repair hash catalogue..."
+POST_HASH=$(cargo run -q -p parx-cli -- hashcat --hash-only "$ROOT")
+echo "POST: $POST_HASH"
+
+if [[ "$BASE_HASH" == "$POST_HASH" ]]; then
+  echo "OK: Dataset hash matches baseline after repair."
+  exit 0
+else
+  echo "FAIL: Dataset hash mismatch after repair." >&2
+  exit 1
+fi
+


### PR DESCRIPTION
- scripts/bench_matrix_local.sh: local-only bench matrix with dataset generation, encode/repair timings, and dataset hash verification via parx hashcat. Writes JSONL to _tgt/bench-results.\n- scripts/bench_repair_smoke.sh: guarded to refuse CI.\n- Makefile: add bench-local and bench-matrix targets.\n- docs/benchmarks.md: document local runners and usage.\n\nAll heavy; no CI wiring.